### PR TITLE
✨ Add sequelize transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "Uses sequelize to access and manipulate process model data.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/process_definition_repository.ts
+++ b/src/process_definition_repository.ts
@@ -52,56 +52,61 @@ export class ProcessDefinitionRepository implements IProcessDefinitionRepository
 
   public async persistProcessDefinitions(name: string, xml: string, overwriteExisting: boolean = true): Promise<void> {
 
-    // Note:
-    // Unfortunately, sequelize doesn't have MIN/MAX operators for WHERE clauses.
-    // So in order to get the latest matching entry, we have to sort by the creation date and
-    // then cherry-pick the first entry.
-    const findExistingDefinitionsQuery: Sequelize.FindOptions<IProcessDefinitionAttributes> = {
-      limit: 1,
-      where: {
-        name: name,
-      },
-      order: [ [ 'createdAt', 'DESC' ]],
-    };
-
-    const newProcessDefinitionHash: string = await this._createHashForProcessDefinition(xml);
-
-    const existingDefinitions: Array<ProcessDefinition> = await this.processDefinition.findAll(findExistingDefinitionsQuery);
-    const existingDefinition: ProcessDefinition = existingDefinitions.length > 0
-      ? existingDefinitions[0]
-      : undefined;
-
-    if (existingDefinition) {
-      if (!overwriteExisting) {
-        throw new ConflictError(`Process definition with the name '${name}' already exists!`);
-      }
-
-      const hashesMatch: boolean = newProcessDefinitionHash === existingDefinition.hash;
-      if (hashesMatch) {
-        // Hashes match: No changes were made.
-        // Just call "save" to update the "updatedAt" timestamp and move on.
-        await existingDefinition.save();
-
-        return;
-      }
-
-      // Hashes do not match: Changes were made.
-      // Create a new entry with the updated hash.
-      const createParams: IProcessDefinitionAttributes = {
-        name: name,
-        xml: xml,
-        hash: newProcessDefinitionHash,
+    await this._sequelize.transaction(async(persistTransaction: Sequelize.Transaction): Promise<void> => {
+      // Note:
+      // Unfortunately, sequelize doesn't have MIN/MAX operators for WHERE clauses.
+      // So in order to get the latest matching entry, we have to sort by the creation date and
+      // then cherry-pick the first entry.
+      const findExistingDefinitionsQuery: Sequelize.FindOptions<IProcessDefinitionAttributes> = {
+        limit: 1,
+        where: {
+          name: name,
+        },
+        transaction: persistTransaction,
+        order: [ [ 'createdAt', 'DESC' ]],
       };
 
-      await this.processDefinition.create(createParams);
-    } else {
+      const newProcessDefinitionHash: string = await this._createHashForProcessDefinition(xml);
 
-      await this.processDefinition.create({
-        name: name,
-        xml: xml,
-        hash: newProcessDefinitionHash,
-      });
-    }
+      const existingDefinitions: Array<ProcessDefinition> = await this.processDefinition.findAll(findExistingDefinitionsQuery);
+      const existingDefinition: ProcessDefinition = existingDefinitions.length > 0
+        ? existingDefinitions[0]
+        : undefined;
+
+      if (existingDefinition) {
+        if (!overwriteExisting) {
+          throw new ConflictError(`Process definition with the name '${name}' already exists!`);
+        }
+
+        const hashesMatch: boolean = newProcessDefinitionHash === existingDefinition.hash;
+        if (hashesMatch) {
+          // Hashes match: No changes were made.
+          // Just call "save" to update the "updatedAt" timestamp and move on.
+          await existingDefinition.save({transaction: persistTransaction});
+
+          return;
+        }
+
+        // Hashes do not match: Changes were made.
+        // Create a new entry with the updated hash.
+        await this.processDefinition.create({
+          name: name,
+          xml: xml,
+          hash: newProcessDefinitionHash,
+        }, {
+          transaction: persistTransaction,
+        });
+      } else {
+
+        await this.processDefinition.create({
+          name: name,
+          xml: xml,
+          hash: newProcessDefinitionHash,
+        }, {
+          transaction: persistTransaction,
+        });
+      }
+    });
   }
 
   public async getProcessDefinitions(): Promise<Array<Runtime.Types.ProcessDefinitionFromRepository>> {

--- a/src/process_definition_repository.ts
+++ b/src/process_definition_repository.ts
@@ -87,7 +87,7 @@ export class ProcessDefinitionRepository implements IProcessDefinitionRepository
 
       // Hashes do not match: Changes were made.
       // Create a new entry with the updated hash.
-      const createParams: any = {
+      const createParams: IProcessDefinitionAttributes = {
         name: name,
         xml: xml,
         hash: newProcessDefinitionHash,
@@ -96,7 +96,7 @@ export class ProcessDefinitionRepository implements IProcessDefinitionRepository
       await this.processDefinition.create(createParams);
     } else {
 
-      await this.processDefinition.create(<any> {
+      await this.processDefinition.create({
         name: name,
         xml: xml,
         hash: newProcessDefinitionHash,


### PR DESCRIPTION
**Changes:**

Implement Sequelize Transaction for the `persistProcessDefinition` UseCase, to prevent database corruption if a request fails.

**Issues:**

Closes #21 
Part of https://github.com/process-engine/process_engine_runtime/issues/188

PR: #22

## How can others test the changes?

To the outside observer, all should work as before.
However, when one query fails during process definition persisting, the entire transaction will be rolled back and no database corruption will occur.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).